### PR TITLE
Implement more partitions and improve partition system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ debug = false
 [features]
 arbitrary = ["nalgebra/arbitrary"]
 
+[dev-dependencies]
+quickcheck = "*"
+quickcheck_macros = "*"
+
 [dependencies.nalgebra]
 git = "https://github.com/sebcrozet/nalgebra"
-
-[dev-dependencies.nalgebra]
-git = "https://github.com/sebcrozet/nalgebra"
-features = ["arbitrary"]
 
 [dependencies.itertools]
 git = "https://github.com/bluss/rust-itertools"
 
-[dev-dependencies]
-quickcheck = "*"
-quickcheck_macros = "*"
+[dev-dependencies.nalgebra]
+git = "https://github.com/sebcrozet/nalgebra"
+features = ["arbitrary"]

--- a/src/partition/boxes.rs
+++ b/src/partition/boxes.rs
@@ -76,8 +76,8 @@ impl_arb_for_box!(Box3, x, y, z);
 
 #[cfg(test)]
 mod test {
-    use nalgebra::{Vec2, Vec3};
-    use super::*;
+    pub use nalgebra::{Vec2, Vec3};
+    pub use super::*;
 
     partition_quickcheck!(box2_f32_partition, Box2<f32>, Vec2<f32>);
     partition_quickcheck!(box2_f64_partition, Box2<f64>, Vec2<f64>);

--- a/src/partition/boxes.rs
+++ b/src/partition/boxes.rs
@@ -3,7 +3,7 @@
 use nalgebra::{Vec2, Vec3};
 #[cfg(any(test, feature = "arbitrary"))]
 use quickcheck::{Arbitrary, Gen};
-use partition::{Partition, Interval, Mid};
+use partition::{Partition, Subdivide, Interval, Mid};
 
 
 macro_rules! impl_box {
@@ -19,7 +19,7 @@ macro_rules! impl_box {
 
 macro_rules! impl_partition_for_box {
     ($b: ident, $v: ident, $($param: ident),*) => (
-        impl<T: Mid + PartialOrd + Copy> Partition<$v<T>> for $b<T> {
+        impl<T: Mid + PartialOrd + Copy> Subdivide for $b<T> {
             fn subdivide(&self) -> Vec<$b<T>> {
                 let mut subs = vec![];
                 $(let $param = self.$param.subdivide();)*
@@ -29,7 +29,9 @@ macro_rules! impl_partition_for_box {
                 );
                 subs
             }
+        }
 
+        impl<T: Mid + PartialOrd + Copy> Partition<$v<T>> for $b<T> {
             fn contains(&self, elem: &$v<T>) -> bool {
                 true $(&& self.$param.contains(&elem.$param))*
             }

--- a/src/partition/cubemap.rs
+++ b/src/partition/cubemap.rs
@@ -1,0 +1,164 @@
+use std::num::cast;
+use nalgebra::{BaseFloat, Vec3, Vec2, zero};
+#[cfg(any(test, feature = "arbitrary"))]
+use quickcheck::{Arbitrary, Gen};
+use partition::{Partition, Subdivide};
+use partition::UnitQuad;
+
+/// An axis direction
+#[derive(Copy, Clone, Show)]
+pub enum Direction { Positive, Negative }
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl Arbitrary for Direction {
+    fn arbitrary<G: Gen>(g: &mut G) -> Direction {
+        match g.gen_range(0, 2) {
+            0 => Direction::Positive,
+            1 => Direction::Negative,
+            _ => unreachable!(),
+        }
+    }
+}
+
+
+/// A coordinate axis
+#[derive(Copy, Clone, Show)]
+pub enum Axis { X, Y, Z }
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl Arbitrary for Axis {
+    fn arbitrary<G: Gen>(g: &mut G) -> Axis {
+        match g.gen_range(0, 3) {
+            0 => Axis::X,
+            1 => Axis::Y,
+            2 => Axis::Z,
+            _ => unreachable!(),
+        }
+    }
+}
+
+
+#[derive(Copy, Clone, Show)]
+pub struct Quad {
+    axis: Axis,
+    direction: Direction,
+    flat_quad: UnitQuad,
+}
+
+impl Subdivide for Quad {
+    fn subdivide(&self) -> Vec<Quad> {
+        self.flat_quad.subdivide()
+            .into_iter()
+            .map(|q| Quad {
+                axis: self.axis,
+                direction: self.direction,
+                flat_quad: q,
+            })
+            .collect()
+    }
+}
+
+impl<T: BaseFloat + PartialOrd> Partition<Vec3<T>> for Quad {
+    fn contains(&self, elem: &Vec3<T>) -> bool {
+        let _1: T = cast(1.0).unwrap();
+        let _2: T = cast(2.0).unwrap();
+        let (i, j, k) = match self.axis {
+            Axis::X => (0, 1, 2),
+            Axis::Y => (1, 2, 0),
+            Axis::Z => (2, 0, 1),
+        };
+        match (elem[i] > zero(), self.direction) {
+            (true, Direction::Positive) | (false, Direction::Negative) =>
+                self.flat_quad.contains(&Vec2::new(
+                    (elem[j] / elem[i] + _1) / _2,
+                    (elem[k] / elem[i] + _1) / _2,
+                )),
+            _ => false,
+        }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl Arbitrary for Quad {
+    fn arbitrary<G: Gen>(g: &mut G) -> Quad {
+        Quad {
+            axis: Arbitrary::arbitrary(g),
+            direction: Arbitrary::arbitrary(g),
+            flat_quad: Arbitrary::arbitrary(g),
+        }
+    }
+}
+
+
+#[derive(Copy, Clone, Show)]
+pub enum CubeMap {
+    Sphere,
+    Quad(Quad),
+}
+
+impl Subdivide for CubeMap {
+    fn subdivide(&self) -> Vec<CubeMap> {
+        println!("{:?}.subdivide()", *self);
+        match *self {
+            CubeMap::Sphere => 
+                vec![
+                    (Direction::Positive, Axis::X),
+                    (Direction::Positive, Axis::Y),
+                    (Direction::Positive, Axis::Z),
+                    (Direction::Negative, Axis::X),
+                    (Direction::Negative, Axis::Y),
+                    (Direction::Negative, Axis::Z),
+                ]
+                .into_iter()
+                .map(|(dir, ax)| CubeMap::Quad(Quad {
+                    axis: ax,
+                    direction: dir,
+                    flat_quad: UnitQuad::new(0, [0, 0]),
+                }))
+                .collect(),
+            CubeMap::Quad(ref quad) =>
+                quad.subdivide().into_iter().map(|q| CubeMap::Quad(q)).collect(),
+        }
+    }
+}
+
+impl<T: BaseFloat + PartialOrd> Partition<Vec3<T>> for CubeMap {
+    fn contains(&self, elem: &Vec3<T>) -> bool {
+        match *self {
+            CubeMap::Sphere => true,
+            CubeMap::Quad(q) => q.contains(elem),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl Arbitrary for CubeMap {
+    fn arbitrary<G: Gen>(g: &mut G) -> CubeMap {
+        match { let s = g.size(); g.gen_range(0, s) } {
+            0 => CubeMap::Sphere,
+            _ => CubeMap::Quad(Arbitrary::arbitrary(g)),
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    pub use nalgebra::Vec3;
+    pub use super::*;
+    use quickcheck::quickcheck;
+    use partition::Partition;
+
+    partition_quickcheck!(quad_vec3_f32, Quad, Vec3<f32>);
+    partition_quickcheck!(quad_vec3_f64, Quad, Vec3<f64>);
+    partition_quickcheck!(cubemap_vec3_f32, CubeMap, Vec3<f32>);
+    partition_quickcheck!(cubemap_vec3_f64, CubeMap, Vec3<f64>);
+
+    #[test]
+    fn cubemap_covers_vec3() {
+        fn check(v: Vec3<f64>) -> bool {
+            CubeMap::Sphere.contains(&v)
+        }
+        quickcheck(check as fn(Vec3<f64>) -> bool);
+    }
+}

--- a/src/partition/interval.rs
+++ b/src/partition/interval.rs
@@ -53,7 +53,7 @@ impl<T: PartialOrd + Arbitrary> Arbitrary for Interval<T> {
 
 #[cfg(test)]
 mod test {
-    use super::Interval;
+    pub use super::Interval;
 
     partition_quickcheck!(interval_f32_partition, Interval<f32>, f32);
     partition_quickcheck!(interval_f64_partition, Interval<f64>, f64);

--- a/src/partition/interval.rs
+++ b/src/partition/interval.rs
@@ -2,7 +2,7 @@
 
 #[cfg(any(test, feature = "arbitrary"))]
 use quickcheck::{Arbitrary, Gen};
-use partition::{Partition, Mid};
+use partition::{Partition, Subdivide, Mid};
 
 
 /// A half-open interval [a, b) between two points a and b
@@ -22,7 +22,7 @@ impl<T: PartialOrd> Interval<T> {
     }
 }
 
-impl<T: Mid + PartialOrd + Copy> Partition<T> for Interval<T> {
+impl<T: Mid + Copy> Subdivide for Interval<T> {
     fn subdivide(&self) -> Vec<Interval<T>> {
         let mid = self.start.mid(&self.end);
         vec![
@@ -30,7 +30,9 @@ impl<T: Mid + PartialOrd + Copy> Partition<T> for Interval<T> {
             Interval { start: mid, end: self.end },
         ]
     }
+}
 
+impl<T: Mid + PartialOrd + Copy> Partition<T> for Interval<T> {
     fn contains(&self, elem: &T) -> bool {
         (self.start <= *elem) && (*elem < self.end)
     }

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -8,20 +8,19 @@ pub use partition::unitquad::UnitQuad;
 #[cfg(any(test, feature = "arbitrary"))]
 use quickcheck::TestResult;
 
+
+/// A type that can be subdivided
+pub trait Subdivide {
+    /// Subdivide into smaller partitions
+    fn subdivide(&self) -> Vec<Self>;
+}
+
+
 /// A type describing a partition of some space
 ///
 /// In addition to this trait signature an implementation is required to satisfy
 /// `prop_is_total`.
-pub trait Partition<T>: Sized {
-    // TODO: uncomment the following, as soon as this bug is fixed.
-    // link: https://github.com/rust-lang/rust/issues/20551
-
-    // The type of subsequent partitions
-    // type Subpartition: Partition<T> = Self;
-
-    /// Subdivide into smaller partitions
-    fn subdivide(&self) -> Vec<Self>;
-
+pub trait Partition<T>: Subdivide + Sized {
     /// Does the partition contain an element?
     fn contains(&self, elem: &T) -> bool;
 

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -73,12 +73,20 @@ pub fn prop_consistent_dispatch<P: Partition<T>, T>(partition: P, elem: T) -> bo
 #[macro_escape]
 macro_rules! partition_quickcheck (
     ($testfn: ident, $p: ty, $t: ty) => (
-        #[test]
-        fn $testfn() {
+        mod $testfn {
             use $crate::partition::{prop_is_total, prop_consistent_dispatch};
             use quickcheck::quickcheck;
-            quickcheck(prop_is_total as fn($p, $t) -> bool);
-            quickcheck(prop_consistent_dispatch as fn($p, $t) -> bool);
+            use super::*;
+
+            #[test]
+            fn is_total() {
+                quickcheck(prop_is_total as fn($p, $t) -> bool);
+            }
+
+            #[test]
+            fn consistent_dispatch() {
+                quickcheck(prop_consistent_dispatch as fn($p, $t) -> bool);
+            }
         }
     )
 );

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -142,3 +142,4 @@ mod interval;
 mod boxes;
 mod ncube;
 mod unitquad;
+mod cubemap;

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -3,6 +3,7 @@
 pub use partition::interval::Interval;
 pub use partition::boxes::{Box2, Box3};
 pub use partition::ncube::Ncube;
+pub use partition::unitquad::UnitQuad;
 
 
 /// A type describing a partition of some space
@@ -110,3 +111,4 @@ impl Mid for f32 {
 mod interval;
 mod boxes;
 mod ncube;
+mod unitquad;

--- a/src/partition/mod.rs
+++ b/src/partition/mod.rs
@@ -5,6 +5,8 @@ pub use partition::boxes::{Box2, Box3};
 pub use partition::ncube::Ncube;
 pub use partition::unitquad::UnitQuad;
 
+#[cfg(any(test, feature = "arbitrary"))]
+use quickcheck::TestResult;
 
 /// A type describing a partition of some space
 ///
@@ -40,19 +42,39 @@ pub trait Partition<T>: Sized {
 }
 
 
-/// Totality proposition
+/// Totality proposition (contained)
 ///
-/// A partition is required to be total, i.e. any element contained in the
-/// partition will be contained in exactly one of its subdivided partitions.
-/// At the same time, an element not contained in the partition can not be
-/// contained by any subdivided partition.
-pub fn prop_is_total<P: Partition<T>, T>(partition: P, elem: T) -> bool {
-    let subs = partition.subdivide();
+/// Any element contained in the partition will be contained in exactly one of
+/// its subpartitions.
+#[cfg(any(test, feature = "arbitrary"))]
+pub fn prop_is_total_elem<P: Partition<T>, T>(partition: P, elem: T) -> TestResult {
     if partition.contains(&elem) {
-        subs.iter().filter(|sub| sub.contains(&elem)).count() == 1
+        TestResult::from_bool(
+            partition.subdivide().iter()
+                .filter(|sub| sub.contains(&elem)).count()
+            == 1
+        )
     }
     else {
-        subs.iter().all(|sub| !sub.contains(&elem))
+        TestResult::discard()
+    }
+}
+
+
+/// Totality proposition (not contained)
+///
+/// If a partition does not contain an element, none of its subpartitions
+/// contain it either.
+#[cfg(any(test, feature = "arbitrary"))]
+pub fn prop_is_total_non_elem<P: Partition<T>, T>(partition: P, elem: T) -> TestResult {
+    if partition.contains(&elem) {
+        TestResult::discard()
+    }
+    else {
+        TestResult::from_bool(
+            partition.subdivide().iter()
+                .all(|sub| !sub.contains(&elem))
+        )
     }
 }
 
@@ -61,12 +83,13 @@ pub fn prop_is_total<P: Partition<T>, T>(partition: P, elem: T) -> bool {
 ///
 /// An element contained in the partition must be dispatched consistently, i.e.
 /// the subpartition to which it is dispatched must contain it.
-pub fn prop_consistent_dispatch<P: Partition<T>, T>(partition: P, elem: T) -> bool {
+#[cfg(any(test, feature = "arbitrary"))]
+pub fn prop_consistent_dispatch<P: Partition<T>, T>(partition: P, elem: T) -> TestResult {
     if partition.contains(&elem) {
-        partition.subdivide()[partition.dispatch(&elem)].contains(&elem)
+        TestResult::from_bool(partition.subdivide()[partition.dispatch(&elem)].contains(&elem))
     }
     else {
-        true
+        TestResult::discard()
     }
 }
 
@@ -75,18 +98,26 @@ pub fn prop_consistent_dispatch<P: Partition<T>, T>(partition: P, elem: T) -> bo
 macro_rules! partition_quickcheck (
     ($testfn: ident, $p: ty, $t: ty) => (
         mod $testfn {
-            use $crate::partition::{prop_is_total, prop_consistent_dispatch};
-            use quickcheck::quickcheck;
+            use $crate::partition::{
+                prop_is_total_elem, prop_is_total_non_elem,
+                prop_consistent_dispatch
+            };
+            use quickcheck::{quickcheck, TestResult};
             use super::*;
 
             #[test]
-            fn is_total() {
-                quickcheck(prop_is_total as fn($p, $t) -> bool);
+            fn is_total_elem() {
+                quickcheck(prop_is_total_elem as fn($p, $t) -> TestResult);
+            }
+
+            #[test]
+            fn is_total_non_elem() {
+                quickcheck(prop_is_total_non_elem as fn($p, $t) -> TestResult);
             }
 
             #[test]
             fn consistent_dispatch() {
-                quickcheck(prop_consistent_dispatch as fn($p, $t) -> bool);
+                quickcheck(prop_consistent_dispatch as fn($p, $t) -> TestResult);
             }
         }
     )

--- a/src/partition/ncube.rs
+++ b/src/partition/ncube.rs
@@ -94,8 +94,8 @@ impl<P: Arbitrary, S: PartialOrd + Zero + Arbitrary> Arbitrary for Ncube<P, S> {
 
 #[cfg(test)]
 mod test {
-    use nalgebra::Pnt2;
-    use super::*;
+    pub use nalgebra::Pnt2;
+    pub use super::*;
 
     partition_quickcheck!(ncube_pnt2_f32_partition, Ncube<Pnt2<f32>, f32>, Pnt2<f32>);
 }

--- a/src/partition/ncube.rs
+++ b/src/partition/ncube.rs
@@ -7,7 +7,7 @@ use std::iter::AdditiveIterator;
 use nalgebra::{Dim, BaseFloat, Zero, zero};
 #[cfg(any(test, feature = "arbitrary"))]
 use quickcheck::{Arbitrary, Gen};
-use partition::Partition;
+use partition::{Partition, Subdivide};
 
 
 /// An N-cube based partitioning scheme
@@ -33,7 +33,7 @@ impl<P: Copy, S: Copy> Ncube<P, S> {
     pub fn center(&self) -> P { self.center }
 }
 
-impl<P, S> Partition<P> for Ncube<P, S>
+impl<P, S> Subdivide for Ncube<P, S>
     where P: Dim + Index<usize, Output=S> + IndexMut<usize, Output=S> + Copy,
           S: BaseFloat + PartialOrd,
 {
@@ -59,7 +59,12 @@ impl<P, S> Partition<P> for Ncube<P, S>
             })
         .collect()
     }
+}
 
+impl<P, S> Partition<P> for Ncube<P, S>
+    where P: Dim + Index<usize, Output=S> + IndexMut<usize, Output=S> + Copy,
+          S: BaseFloat + PartialOrd,
+{
     fn contains(&self, elem: &P) -> bool {
         let _2 = cast(2.0f64).unwrap();
         (0..Dim::dim(None::<P>))

--- a/src/partition/unitquad.rs
+++ b/src/partition/unitquad.rs
@@ -2,7 +2,7 @@ use std::num::{Int, Float, cast};
 #[cfg(any(test, feature = "arbitrary"))]
 use quickcheck::{Arbitrary, Gen};
 use nalgebra::{Vec2, BaseFloat};
-use partition::Partition;
+use partition::{Partition, Subdivide};
 
 
 /// A partition of the unit quad [0, 1) × [0, 1)
@@ -24,8 +24,7 @@ impl UnitQuad {
     }
 }
 
-impl<T: BaseFloat> Partition<Vec2<T>> for UnitQuad
-{
+impl Subdivide for UnitQuad {
     fn subdivide(&self) -> Vec<UnitQuad> {
         [(0, 0), (0, 1), (1, 0), (1, 1)]
             .iter()
@@ -35,7 +34,10 @@ impl<T: BaseFloat> Partition<Vec2<T>> for UnitQuad
             })
             .collect()
     }
+}
 
+impl<T: BaseFloat> Partition<Vec2<T>> for UnitQuad
+{
     fn contains(&self, elem: &Vec2<T>) -> bool {
         let width = cast::<_, T>(0.5).unwrap().powi(self.scale as i32);
         let offset = Vec2::new(

--- a/src/partition/unitquad.rs
+++ b/src/partition/unitquad.rs
@@ -1,0 +1,77 @@
+use std::num::{Int, Float, cast};
+#[cfg(any(test, feature = "arbitrary"))]
+use quickcheck::{Arbitrary, Gen};
+use nalgebra::{Vec2, BaseFloat};
+use partition::Partition;
+
+
+/// A partition of the unit quad [0, 1) × [0, 1)
+#[derive(Copy, Clone, Show)]
+pub struct UnitQuad {
+    scale: u8,
+    offset: [u32; 2],
+}
+
+impl UnitQuad {
+    /// Create a new `UnitQuad`
+    ///
+    /// This asserts that the offset is valid given the scale level.
+    pub fn new(scale: u8, offset: [u32; 2]) -> UnitQuad {
+        assert!(scale < 32); // Otherwise exponentiation will overflow
+        let max_offset = 2.pow(scale as usize);
+        assert!(offset.iter().all(|&x| x < max_offset));
+        UnitQuad { scale: scale, offset: offset }
+    }
+}
+
+impl<T: BaseFloat> Partition<Vec2<T>> for UnitQuad
+{
+    fn subdivide(&self) -> Vec<UnitQuad> {
+        [(0, 0), (0, 1), (1, 0), (1, 1)]
+            .iter()
+            .map(|&(di, dj)| {
+                let [i, j] = self.offset;
+                UnitQuad::new(self.scale + 1, [i + di, j + dj])
+            })
+            .collect()
+    }
+
+    fn contains(&self, elem: &Vec2<T>) -> bool {
+        let width = cast::<_, T>(0.5).unwrap().powi(self.scale as i32);
+        let offset = Vec2::new(
+            width * cast(self.offset[0]).unwrap(),
+            width * cast(self.offset[1]).unwrap(),
+        );
+        (offset.x < elem.x) && (elem.x < offset.x + width) &&
+        (offset.y < elem.y) && (elem.y < offset.y + width)
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl Arbitrary for UnitQuad {
+    fn arbitrary<G: Gen>(g: &mut G) -> UnitQuad {
+        use std::cmp;
+        let scale: u8 = {
+            // scale >= 32 is invalid (overflow)
+            // At scale >= 31 subdivision fails
+            let max_scale = cmp::min(31, g.size()) as u8;
+            g.gen_range(0, max_scale)
+        };
+        let max_offset = 2.pow(scale as usize);
+        println!("{:?}", (scale, max_offset));
+        UnitQuad::new(scale, [
+            g.gen_range(0, max_offset),
+            g.gen_range(0, max_offset),
+        ])
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    pub use nalgebra::Vec2;
+    pub use super::*;
+
+    partition_quickcheck!(unitquad_vec2_f32, UnitQuad, Vec2<f32>);
+    partition_quickcheck!(unitquad_vec2_f64, UnitQuad, Vec2<f64>);
+}

--- a/src/partition/unitquad.rs
+++ b/src/partition/unitquad.rs
@@ -53,6 +53,11 @@ impl<T: BaseFloat> Partition<Vec2<T>> for UnitQuad
 impl Arbitrary for UnitQuad {
     fn arbitrary<G: Gen>(g: &mut G) -> UnitQuad {
         use std::cmp;
+        // FIXME: somehow this explicit usage of the `Rng` trait is required for
+        // the `.gen_range` calls, even though `Rng: Gen`. The compiler
+        // complains that the "source trait is private". Curiously, adding this
+        // import here fixes the same situation in the `cubemap` module as well.
+        use std::rand::Rng;
         let scale: u8 = {
             // scale >= 32 is invalid (overflow)
             // At scale >= 31 subdivision fails

--- a/src/partition/unitquad.rs
+++ b/src/partition/unitquad.rs
@@ -30,7 +30,7 @@ impl Subdivide for UnitQuad {
             .iter()
             .map(|&(di, dj)| {
                 let [i, j] = self.offset;
-                UnitQuad::new(self.scale + 1, [i + di, j + dj])
+                UnitQuad::new(self.scale + 1, [i * 2 + di, j * 2 + dj])
             })
             .collect()
     }
@@ -60,7 +60,6 @@ impl Arbitrary for UnitQuad {
             g.gen_range(0, max_scale)
         };
         let max_offset = 2.pow(scale as usize);
-        println!("{:?}", (scale, max_offset));
         UnitQuad::new(scale, [
             g.gen_range(0, max_offset),
             g.gen_range(0, max_offset),
@@ -73,7 +72,21 @@ impl Arbitrary for UnitQuad {
 mod test {
     pub use nalgebra::Vec2;
     pub use super::*;
+    use quickcheck::{quickcheck, TestResult};
+    use partition::Partition;
 
     partition_quickcheck!(unitquad_vec2_f32, UnitQuad, Vec2<f32>);
     partition_quickcheck!(unitquad_vec2_f64, UnitQuad, Vec2<f64>);
+
+    #[test]
+    fn unitquad_base_contains_region() {
+        fn check(v: Vec2<f64>) -> TestResult {
+            if v.x < 0.0 || v.x >= 1.0 || v.y < 0.0 || v.y >= 1.0 {
+                TestResult::discard()
+            } else {
+                TestResult::from_bool(UnitQuad::new(0, [0, 0]).contains(&v))
+            }
+        }
+        quickcheck(check as fn(Vec2<f64>) -> TestResult);
+    }
 }


### PR DESCRIPTION
New features:

- `UnitQuad` partitions [0, 1) × [0, 1) in a quadtree-like fashion.
- `CubeMap` partitions the whole ℝ³ by projecting it onto the surface of a unit cube and partitioning each side like `UnitQuad`. This is mainly intended for partitioning the surface of a 2-sphere.

Breaking changes:

- `Partition::subdivide(&self)` has been split off as its own subtrait `Subdivide`, from which `Partition: Subdivide` inherits.
- The totality propositions now directly depend on quickcheck, as this reproduces failures more reliably.