### PR TITLE
Use tuples for unit quad

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,13 @@ license = "GPL-3.0+"
 debug = false
 
 [features]
-arbitrary = ["nalgebra/arbitrary"]
+arbitrary = ["nalgebra/arbitrary", "quickcheck"]
+
+[dependencies.quickcheck]
+optional = true
 
 [dev-dependencies]
 quickcheck = "*"
-quickcheck_macros = "*"
 
 [dependencies.nalgebra]
 git = "https://github.com/sebcrozet/nalgebra"

--- a/src/partition/cubemap.rs
+++ b/src/partition/cubemap.rs
@@ -198,7 +198,7 @@ impl Subdivide for CubeMap {
                 .map(|(dir, ax)| CubeMap::Quad(Quad {
                     axis: ax,
                     direction: dir,
-                    flat_quad: UnitQuad::new(0, [0, 0]),
+                    flat_quad: UnitQuad::new(0, (0, 0)),
                 }))
                 .collect(),
             CubeMap::Quad(ref quad) =>


### PR DESCRIPTION
Fixed-size arrays no longer implement Hash, so UnitQuad has to use a tuple to store its offset. For sake of consistency, coordinates are now also handled as a tuple.