### PR TITLE
Explicitly use unstable features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A spatial tree library
 
 #![warn(missing_docs)]
-#![allow(unstable)] // FIXME: remove this towards Rust 1.0
+#![feature(core, hash)]
 
 extern crate nalgebra;
 #[macro_use]

--- a/src/partition/boxes.rs
+++ b/src/partition/boxes.rs
@@ -52,7 +52,7 @@ macro_rules! impl_arb_for_box {
 
 
 /// A 2d box of intervals
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 pub struct Box2<T> {
     x: Interval<T>,
     y: Interval<T>,
@@ -64,7 +64,7 @@ impl_arb_for_box!(Box2, x, y);
 
 
 /// A 3d box of intervals
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 pub struct Box3<T> {
     x: Interval<T>,
     y: Interval<T>,

--- a/src/partition/cubemap.rs
+++ b/src/partition/cubemap.rs
@@ -11,7 +11,7 @@ use partition::UnitQuad;
 ///
 /// This effectively distinguishes whether we are moving in positive or negative
 /// direction along some axis, i.e. +X vs -X, +Y vs. -Y etc.
-#[derive(Copy, Clone, Show, PartialEq, Hash, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub enum Direction {
     /// Positive direction
     Positive,
@@ -33,7 +33,7 @@ impl Arbitrary for Direction {
 
 
 /// A coordinate axis
-#[derive(Copy, Clone, Show, PartialEq, Hash, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub enum Axis {
     /// X-axis
     X,
@@ -91,7 +91,7 @@ pub fn axis_vector_triple<T: BaseFloat>(axis: Axis, direction: Direction) -> [Ve
 
 
 /// A quad-shaped partition of the side of a cubemap
-#[derive(Copy, Clone, Show, PartialEq, Hash, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct Quad {
     /// Normal axis of the quad normal
     pub axis: Axis,
@@ -173,7 +173,7 @@ impl Arbitrary for Quad {
 /// a 2-sphere (which is a subset of the full ℝ³). It is either the full
 /// spherical dome or some subdivision stage on one of the six quad-shape sides
 /// obtained by projecting the sphere onto a cube.
-#[derive(Copy, Clone, Show, PartialEq, Hash, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub enum CubeMap {
     /// The full sphere
     Sphere,

--- a/src/partition/interval.rs
+++ b/src/partition/interval.rs
@@ -6,7 +6,7 @@ use partition::{Partition, Subdivide, Mid};
 
 
 /// A half-open interval [a, b) between two points a and b
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 pub struct Interval<T> {
     start: T,
     end: T,

--- a/src/partition/ncube.rs
+++ b/src/partition/ncube.rs
@@ -11,7 +11,7 @@ use partition::{Partition, Subdivide};
 
 
 /// An N-cube based partitioning scheme
-#[derive(Copy, Clone, Show)]
+#[derive(Copy, Clone, Debug)]
 pub struct Ncube<P, S> {
     center: P,
     width: S,

--- a/src/partition/unitquad.rs
+++ b/src/partition/unitquad.rs
@@ -6,7 +6,7 @@ use partition::{Partition, Subdivide};
 
 
 /// A partition of the unit quad [0, 1) × [0, 1)
-#[derive(Copy, Clone, Show, PartialEq, Hash, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Hash, Eq)]
 pub struct UnitQuad {
     scale: u8,
     offset: (u32, u32),


### PR DESCRIPTION
The currently still unstable features core and hash are used in the crate. The `Show` trait has been renamed to `Debug` in the standard library.