### PR TITLE
Upgrade to new nalgebra version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = false
 arbitrary = ["nalgebra/arbitrary", "quickcheck"]
 
 [dependencies]
-nalgebra = "0.2"
+nalgebra = "0.3"
 itertools = "0.3"
 rand = "0.3"
 num = "0.1"
@@ -29,4 +29,5 @@ optional = true
 quickcheck = "0.2"
 
 [dev-dependencies.nalgebra]
+version = "0.3"
 features = ["arbitrary"]

--- a/tests/tree_gravity.rs
+++ b/tests/tree_gravity.rs
@@ -1,7 +1,5 @@
 //! Simple integration tests oriented towards gravity computations
 
-#![feature(core)]
-
 extern crate acacia;
 extern crate nalgebra;
 extern crate quickcheck;


### PR DESCRIPTION
nalgebra 0.3 works fine here. Also left out the superfluous `core` feature in this version.

Fixes #75.