### PR TITLE
Allow nalgebra versions >=0.9, <1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ debug = false
 arbitrary = ["nalgebra/arbitrary", "quickcheck"]
 
 [dependencies]
-nalgebra = "0.9"
+nalgebra = ">=0.9, <1.0"
 itertools = "0.4"
 rand = "0.3"
 num = "0.1"
@@ -30,5 +30,5 @@ version = "0.2"
 quickcheck = "0.2"
 
 [dev-dependencies.nalgebra]
-version = "0.9"
+version = ">=0.9, <1.0"
 features = ["arbitrary"]


### PR DESCRIPTION
nalgebra didn't bump the major version for the name changes they introduced in 0.9, but we should be fine to accept later versions.